### PR TITLE
docs(readme): incluir badge do ServeRest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Serenity-Rest-Assured-Exemplo
 
+[![Badge ServeRest](https://img.shields.io/badge/API-ServeRest-green)](https://github.com/ServeRest/ServeRest/)
+
 Projeto contendo algumas requisições para a api Serverest. Utilizando o framework Serenitybdd, rest-assured e cucumber contidos todos dentro do framework.


### PR DESCRIPTION
@niltonSugawara muito bom o seu projeto, bem agregador :D
O que acha de adicionar o badge do ServeRest na documentação?
Para ver como fica, acesse: https://github.com/PauloGoncalvesBH/Serenity-Rest-Assured-Exemplo/blob/patch-2/README.md